### PR TITLE
Pulls in LC_TIME env variable on greeter start

### DIFF
--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -125,6 +125,7 @@ namespace SDDM {
             QProcessEnvironment env;
             QProcessEnvironment sysenv = QProcessEnvironment::systemEnvironment();
             env.insert("LANG", sysenv.value("LANG"));
+            env.insert("LC_TIME", sysenv.value("LC_TIME"));
             env.insert("PATH", mainConfig.Users.DefaultPath.get());
             env.insert("DISPLAY", m_display->name());
             env.insert("XAUTHORITY", m_authPath);


### PR DESCRIPTION
User may set different LC_TIME apart from LANG, like myself, 
for different datetime format shown in the greeter.
In my case, I am a Chinese speaker living in Japan, 
therefore I have LANG=zh_CN while LC_TIME=ja_JP.
Currently the lock screen of KDE5 set the LC_TIME correctly, 
but the login greeter use only LANG.
This change makes lock screen and login greeter behave the same.
